### PR TITLE
Timeout branch

### DIFF
--- a/submodules/menu/menu.js
+++ b/submodules/menu/menu.js
@@ -342,6 +342,7 @@ define(function(require){
 						popup_html = $(monster.template(self, 'menu-callflowKey', {
 							items: {
 								'_': self.i18n.active().callflows.menu.default_action,
+								'timeout': 'timeout',
 								'0': '0',
 								'1': '1',
 								'2': '2',


### PR DESCRIPTION
In kazoo/application/callflows/src/module/cf_menu.erl:135 there is defined the Digit "timeout" for defining an action in case of timeout (so timeout is not handled like an invalid entry).
Adding this, will show on the callflow the menu option "timeout" and works correctly.
