### PR TITLE
Change device outbound caller id text inputs to dropdowns

### DIFF
--- a/submodules/device/device.js
+++ b/submodules/device/device.js
@@ -319,14 +319,14 @@ define(function(require) {
 					},
 					function(err, results) {
 						var render_data = self.devicePrepareDataForTemplate(data, defaults, $.extend(true, results, {
-							get_device: deviceData
-						})),
-						mainNumbers = {};
+								get_device: deviceData
+							})),
+							mainNumbers = {};
 
 						$.each(results.user_numbers.numbers, function(k, number) {
 							if (results.user_numbers.numbers.hasOwnProperty(k)) {
 								var settings = results.user_numbers.numbers[k];
-									// Only include phone numbers that are in service and not on a sub-account.
+								// Only include phone numbers that are in service and not on a sub-account.
 								if (settings.state === 'in_service' && !settings.on_subaccount) {
 									mainNumbers[k] = number;
 								}

--- a/submodules/device/device.js
+++ b/submodules/device/device.js
@@ -217,6 +217,11 @@ define(function(require) {
 								}
 							});
 						},
+						user_numbers: function(callback) {
+							self.userListNumbers(function(_data) {
+								callback(null, _data);
+							});
+						},
 						account: function(callback) {
 							self.callApi({
 								resource: 'account.get',
@@ -315,7 +320,20 @@ define(function(require) {
 					function(err, results) {
 						var render_data = self.devicePrepareDataForTemplate(data, defaults, $.extend(true, results, {
 							get_device: deviceData
-						}));
+						})),
+						mainNumbers = {};
+
+						$.each(results.user_numbers.numbers, function(k, number) {
+							if (results.user_numbers.numbers.hasOwnProperty(k)) {
+								var settings = results.user_numbers.numbers[k];
+									// Only include phone numbers that are in service and not on a sub-account.
+								if (settings.state === 'in_service' && !settings.on_subaccount) {
+									mainNumbers[k] = number;
+								}
+							}
+						});
+
+						render_data = $.extend(true, defaults, { data: results.user_get, mainNumbers: mainNumbers });
 
 						self.deviceRender(render_data, target, callbacks);
 
@@ -344,6 +362,20 @@ define(function(require) {
 			} else {
 				parallelRequests(defaults);
 			}
+		},
+
+		userListNumbers: function(callback) {
+			var self = this;
+
+			self.callApi({
+				resource: 'numbers.list',
+				data: {
+					accountId: self.accountId
+				},
+				success: function(data) {
+					callback && callback(data.data);
+				}
+			});
 		},
 
 		devicePrepareDataForTemplate: function(data, dataGlobal, results) {

--- a/views/device-ata.html
+++ b/views/device-ata.html
@@ -110,7 +110,12 @@
 					<div class="clearfix">
 						<label for="caller_id_number_external">{{ i18n.callflows.device.caller_id_number }}</label>
 						<div class="input">
-							<input class="span4" id="caller_id_number_external" name="caller_id.external.number" type="text" placeholder="+15555555555" value="{{ data.caller_id.external.number }}" rel="popover" data-content="{{ i18n.callflows.device.caller_id_number_data_content2 }}"/>
+							<select name="caller_id.external.number" id="advanced_caller_id_number_external" class="caller-id-select">
+								<option{{#compare data.caller_id.external.number "===" ""}} selected{{/compare}} value="">None</option>
+								{{#each mainNumbers}}
+								<option{{#compare ../data.caller_id.external.number "===" @key}} selected{{/compare}} value="{{@key}}">{{formatPhoneNumber @key}}</option>
+								{{/each}}
+							</select>
 						</div>
 					</div>
 					<hr />

--- a/views/device-fax.html
+++ b/views/device-fax.html
@@ -125,7 +125,12 @@
 					<div class="clearfix">
 						<label for="caller_id_number_external">{{ i18n.callflows.device.caller_id_number }}</label>
 						<div class="input">
-							<input class="span4" id="caller_id_number_external" name="caller_id.external.number" type="text" placeholder="+15555555555" value="{{ data.caller_id.external.number }}" rel="popover" data-content="{{ i18n.callflows.device.caller_id_number_data_content2 }}"/>
+							<select name="caller_id.external.number" id="advanced_caller_id_number_external" class="caller-id-select">
+								<option{{#compare data.caller_id.external.number "===" ""}} selected{{/compare}} value="">None</option>
+								{{#each mainNumbers}}
+								<option{{#compare ../data.caller_id.external.number "===" @key}} selected{{/compare}} value="{{@key}}">{{formatPhoneNumber @key}}</option>
+								{{/each}}
+							</select>
 						</div>
 					</div>
 					<hr />

--- a/views/device-sip_device.html
+++ b/views/device-sip_device.html
@@ -156,7 +156,12 @@
 					<div class="clearfix">
 						<label for="caller_id_number_external">{{ i18n.callflows.device.caller_id_number }}</label>
 						<div class="input">
-							<input class="span4" id="caller_id_number_external" name="caller_id.external.number" type="text" placeholder="+15555555555" value="{{ data.caller_id.external.number }}" rel="popover" data-content="{{ i18n.callflows.device.caller_id_number_data_content2 }}"/>
+							<select name="caller_id.external.number" id="advanced_caller_id_number_external" class="caller-id-select">
+								<option{{#compare data.caller_id.external.number "===" ""}} selected{{/compare}} value="">None</option>
+								{{#each mainNumbers}}
+								<option{{#compare ../data.caller_id.external.number "===" @key}} selected{{/compare}} value="{{@key}}">{{formatPhoneNumber @key}}</option>
+								{{/each}}
+							</select>
 						</div>
 					</div>
 					<hr />

--- a/views/device-softphone.html
+++ b/views/device-softphone.html
@@ -126,7 +126,12 @@
 					<div class="clearfix">
 						<label for="caller_id_number_external">{{ i18n.callflows.device.caller_id_number }}</label>
 						<div class="input">
-							<input class="span4" id="caller_id_number_external" name="caller_id.external.number" type="text" placeholder="+15555555555" value="{{ data.caller_id.external.number }}" rel="popover" data-content="{{ i18n.callflows.device.caller_id_number_data_content2 }}"/>
+							<select name="caller_id.external.number" id="advanced_caller_id_number_external" class="caller-id-select">
+								<option{{#compare data.caller_id.external.number "===" ""}} selected{{/compare}} value="">None</option>
+								{{#each mainNumbers}}
+								<option{{#compare ../data.caller_id.external.number "===" @key}} selected{{/compare}} value="{{@key}}">{{formatPhoneNumber @key}}</option>
+								{{/each}}
+							</select>
 						</div>
 					</div>
 


### PR DESCRIPTION
This limits the potential outbound caller ids for a device to in-service numbers owned by the account.