### PR TITLE
Change user outbound caller id text inputs to dropdowns

### DIFF
--- a/views/user-edit.html
+++ b/views/user-edit.html
@@ -131,7 +131,12 @@
 				<div class="clearfix">
 					<label for="caller_id_number_external">{{ i18n.callflows.user.caller_id_number }}</label>
 					<div class="input">
-						<input class="span4" id="caller_id_number_external" name="caller_id.external.number" type="text" placeholder="+15555555555" value="{{data.caller_id.external.number}}" rel="popover" data-content="{{ i18n.callflows.user.caller_id_number_data_content2 }}"/>
+						<select name="caller_id.external.number" id="advanced_caller_id_number_external" class="caller-id-select">
+							<option{{#compare data.caller_id.external.number "===" ""}} selected{{/compare}} value="">None</option>
+							{{#each mainNumbers}}
+								<option{{#compare ../data.caller_id.external.number "===" @key}} selected{{/compare}} value="{{@key}}">{{formatPhoneNumber @key}}</option>
+							{{/each}}
+						</select>
 					</div>
 				</div>
 
@@ -194,7 +199,12 @@
 				<div class="clearfix">
 					<label for="advanced_caller_id_number_external">{{ i18n.callflows.user.caller_id_number }}</label>
 					<div class="input">
-						<input class="span4" id="advanced_caller_id_number_external" name="caller_id.external.number" type="text" placeholder="+15555555555" value="{{data.caller_id.external.number}}" rel="popover" data-content="{{ i18n.callflows.user.caller_id_number_data_content2 }}"/>
+						<select name="caller_id.external.number" id="advanced_caller_id_number_external" class="caller-id-select">
+							<option{{#compare data.caller_id.external.number "===" ""}} selected{{/compare}} value="">None</option>
+							{{#each mainNumbers}}
+								<option{{#compare ../data.caller_id.external.number "===" @key}} selected{{/compare}} value="{{@key}}">{{formatPhoneNumber @key}}</option>
+							{{/each}}
+						</select>
 					</div>
 				</div>
 				<hr />


### PR DESCRIPTION
This limits the potential outbound caller ids for a user to in-service numbers owned by the account.