### PR TITLE
UI-3126: Do not use jQuery wrapper for templates inserted by Handlebars

### DIFF
--- a/submodules/device/device.js
+++ b/submodules/device/device.js
@@ -1244,11 +1244,12 @@ define(function(require) {
 									deviceIcon: deviceIcons.hasOwnProperty(device.device_type) ? deviceIcons[device.device_type] : deviceIcons.unknown,
 									isRegistered: device.enabled ? (['sip_device', 'smartphone', 'softphone', 'fax', 'ata'].indexOf(device.device_type) >= 0 ? registeredDevices.indexOf(device.id) >= 0 : true) : false
 								};
-								device.customEntityTemplate = $(self.getTemplate({
+								// no jQuery wrapper since this template will be inserted directly with Handlebars
+								device.customEntityTemplate = self.getTemplate({
 									name: 'entity-element',
 									data: dataTemplate,
 									submodule: 'device'
-								}));
+								});
 							});
 
 							callback && callback(results.device);


### PR DESCRIPTION
We usually insert templates using jQuery methods but it is possible to
do it manually by passing them as regular data to another template.