### PR TITLE
UI-3353: Fix extension formatting on flow rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -869,7 +869,9 @@ define(function(require) {
 
 			_.each(data.data, function(callflow) {
 				var formattedNumbers = _.map(callflow.numbers || '-', function(number) {
-						return monster.util.formatPhoneNumber(number);
+						return _.startsWith('+', number)
+							? monster.util.formatPhoneNumber(number)
+							: number;
 					}),
 					listNumbers = formattedNumbers.toString(),
 					isFeatureCode = callflow.featurecode !== false && !_.isEmpty(callflow.featurecode);
@@ -1452,7 +1454,11 @@ define(function(require) {
 							row = $(self.getTemplate({
 								name: 'rowNumber',
 								data: {
-									numbers: numbers
+									numbers: _.map(numbers, function(number) {
+										return _.startsWith('+', number)
+											? monster.util.formatPhoneNumber(number)
+											: number;
+									})
 								}
 							}));
 

--- a/views/rowNumber.html
+++ b/views/rowNumber.html
@@ -7,7 +7,7 @@
 				{{#compare numbers.[0] "===" ""}}
 					{{ i18n.oldCallflows.no_number }}
 				{{else}}
-					{{ formatPhoneNumber numbers.[0] }}
+					{{ numbers.[0] }}
 				{{/compare}}
 			{{/compare}}
 			<span class="delete"/>
@@ -20,7 +20,7 @@
 				{{#compare numbers.[1] "===" ""}}
 					{{ i18n.oldCallflows.no_number }}
 				{{else}}
-					{{ formatPhoneNumber numbers.[1] }}
+					{{ numbers.[1] }}
 				{{/compare}}
 			{{/compare}}
 			<span class="delete"/>
@@ -34,7 +34,7 @@
 					{{#compare numbers.[0] "===" ""}}
 						{{ i18n.oldCallflows.no_number }}
 					{{else}}
-						{{ formatPhoneNumber numbers.[0] }}
+						{{ numbers.[0] }}
 					{{/compare}}
 				{{/compare}}
 				<span class="delete"/>


### PR DESCRIPTION
Moved number/extension formatting away from the template following the
update of `monster.util.formatPhoneNumber` helper that now format phone
numbers only.