### PR TITLE
MONUI-116: Tweak callflow toolbar styles

### DIFF
--- a/style/app.css
+++ b/style/app.css
@@ -202,6 +202,7 @@
 #ws_callflow .tools .inactive .open,
 .callflow-preview .tools .inactive .open{
 	background-image: url(static/images/arrow_inactive.png);
+	cursor: pointer;
 }
 
 #ws_callflow .tools .tool,
@@ -617,6 +618,7 @@
 #ws_callflow .tools .search-box,
 .callflow-preview .tools .search-box {
 	background: #444;
+	position: relative;
 }
 
 #ws_callflow .tools .search-box input,


### PR DESCRIPTION
Just a couple little tweaks to the styling on the callflows editor's toolbar

| Change | Before | After |
|---------|--------|------|
| Properly position the search icon so it moves with the input on scroll | <img width="185" alt="Screen Shot 2020-05-11 at 6 09 30 PM" src="https://user-images.githubusercontent.com/26111569/81627312-bc401700-93b2-11ea-851f-a3a35564d84c.png"> | <img width="181" alt="Screen Shot 2020-05-11 at 6 10 35 PM" src="https://user-images.githubusercontent.com/26111569/81627320-c235f800-93b2-11ea-846c-4f85daa553fa.png"> |
| Use pointer on 'inactive' categories' | <img width="175" alt="Before" src="https://user-images.githubusercontent.com/26111569/81717882-f7346000-942f-11ea-8a3f-3f43c9363138.png"> | <img width="175" alt="After" src="https://user-images.githubusercontent.com/26111569/81717905-fc91aa80-942f-11ea-892f-fc51a1949abe.png"> |

