### PR TITLE
MONUI-116: Add breadcrumbs to callflow and move save and delete buttons

### DIFF
--- a/app.js
+++ b/app.js
@@ -334,6 +334,20 @@ define(function(require) {
 				template.find('.entity-manager').show();
 			});
 
+			// Clicking the 'Callflows' breadcrumb closes any open callflow
+			template.on('click', '.entity-header .hide-callflow', function() {
+				$('#ws_cf_flow').empty();
+				$('.buttons').empty();
+				$('#ws_cf_tools').empty();
+				$('#hidden_callflow_warning').hide();
+				$('#pending_change').hide();
+				$('.breadcrumbs .current').empty();
+				$('.breadcrumbs span:first-child').addClass('hide-separator');
+
+				self.repaintList();
+				self.resetFlow();
+			});
+
 			template.find('.entity-edition .list-add').on('click', function() {
 				var type = template.find('.entity-edition .list-container .list').data('type');
 				editEntity(type);
@@ -983,6 +997,8 @@ define(function(require) {
 								$('.buttons').empty();
 								$('#ws_cf_tools').empty();
 								$('#hidden_callflow_warning').hide();
+								$('.breadcrumbs .current').empty();
+								$('.breadcrumbs span:first-child').addClass('hide-separator');
 
 								self.repaintList();
 								self.resetFlow();
@@ -1242,6 +1258,14 @@ define(function(require) {
 				self.show_pending_change(self.original_flow !== current_flow);
 			}
 
+			// Add the name of the current callflow (or its numbers if no name given)
+			// to the breadcrumbs in the action bar
+			const callflowTitle = this.flow.name
+				|| this.flow.numbers.join(', ')
+				|| this.i18n.active().callflowsApp.editor.current;
+			$('.entity-header .breadcrumbs .current').text(callflowTitle);
+			$('.breadcrumbs .hide-separator').removeClass('hide-separator');
+
 			var metadata = self.dataCallflow.hasOwnProperty('ui_metadata') ? self.dataCallflow.ui_metadata : false,
 				isHiddenCallflow = metadata && metadata.hasOwnProperty('origin') && _.includes(['voip', 'migration', 'mobile', 'callqueues'], metadata.origin);
 
@@ -1252,10 +1276,10 @@ define(function(require) {
 			var self = this;
 			if (pending_change) {
 				$('#pending_change', '#ws_callflow').show();
-				$('.save', '#ws_callflow').addClass('pulse-box');
+				$('.entity-header .save', '#callflow_container').addClass('pulse-box');
 			} else {
 				$('#pending_change', '#ws_callflow').hide();
-				$('.save', '#ws_callflow').removeClass('pulse-box');
+				$('.entity-header .save', '#callflow_container').removeClass('pulse-box');
 			}
 		},
 

--- a/style/app.css
+++ b/style/app.css
@@ -1594,6 +1594,40 @@
 	float: right;
 }
 
+#callflow_container .entity-header .breadcrumbs {
+	float: left;
+}
+#callflow_container .entity-header .breadcrumbs .entity-title {
+	float: none;
+	font-size: 19px;
+}
+#callflow_container .entity-header .breadcrumbs a {
+	color: black;
+	cursor: pointer;
+}
+#callflow_container .entity-header .breadcrumbs a:hover {
+	border-bottom: 2px solid black;
+}
+#callflow_container .entity-header .breadcrumbs span {
+	color: black;
+	font-size: 19px;
+}
+#callflow_container .entity-header .breadcrumbs span.current {
+	font-weight: 600;
+	border-bottom: 2px solid black;
+}
+#callflow_container .entity-header .breadcrumbs span:not(.current):not(.hide-separator):after {
+	content: "\03031";
+	display: inline-block;
+	font-size: 13px;
+	margin: 0 8px 0 10px;
+	transform: scaleX(-1.2) translateY(-1px);
+}
+
+#callflow_container .entity-header .buttons {
+	float: right;
+}
+
 #callflow_container .entity-header .superadmin-mode {
 	float: right;
 	line-height: 35px;

--- a/views/callflow-manager.html
+++ b/views/callflow-manager.html
@@ -15,9 +15,15 @@
 
 	<div class="callflow-content listing-mode">
 		<div class="entity-header">
-			<div class="entity-title">{{ i18n.entityManager.callflowsTitle }}</div>
-			
+			<nav class="breadcrumbs">
+				<span class="hide-separator">
+					<a class="hide-callflow entity-title">{{ i18n.entityManager.callflowsTitle }}</a>
+				</span>
+				<span class="current"></span>
+			</nav>
+
 			<button type="button" class="back-button monster-button-secondary">{{ i18n.entityManager.backButton }}</button>
+			<div class="buttons"></div>
 			{{#if canToggleCallflows}}
 				<div class="superadmin-mode">
 					<span class="switch-title">
@@ -48,7 +54,6 @@
 						<div class="callflow">
 							<div>
 								<span class="flow">
-									<div class="buttons"></div>
 									<div id="ws_cf_flow"></div>
 								</span>
 							</div>


### PR DESCRIPTION
We've made some changes to the layout of the callflows editor, I'll leave them here if you want to take a look:

- Added breadcrumb nav showing the current callflow (clicking 'Callflows' closes the current callflow but leaves the list open)
- Moved the save/delete buttons into the action bar

<img width="1204" alt="Screen Shot 2020-05-14 at 11 24 55 AM" src="https://user-images.githubusercontent.com/26111569/81971258-aa8a8980-95d5-11ea-81ec-43af29109a2a.png">
