### PR TITLE
MONUI-121: Add reboot-device button

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -248,7 +248,10 @@
 					"number": "Please enter a valid phone number",
 					"realm": "Please enter a valid realm"
 				}
-			}
+			},
+			"reboot": "Reboot",
+			"reboot_confirm": "Are you sure you want to reboot this device?",
+			"reboot_success": "Reboot Command Sent"
 		},
 		"disa": {
 			"title": "DISA",

--- a/submodules/device/views/device-sip_device.html
+++ b/submodules/device/views/device-sip_device.html
@@ -450,6 +450,7 @@
 
 		<div class="buttons-right">
 			{{#if data.id}}
+				<button class="monster-button monster-button-primary device-reboot">{{ i18n.callflows.device.reboot }}</button>
 				<button class="monster-button monster-button-danger device-delete">{{ i18n.callflows.device.delete }}</button>
 			{{/if}}
 			<button class="monster-button monster-button-success device-save">{{ i18n.callflows.device.save }}</button>


### PR DESCRIPTION
I've brought over a button from KazooUI to trigger a reboot on SIP phones (posting to the `accounts/{accountId}/devices/{deviceId}/sync` endpoint), if this is of any interest to you.

<img width="945" alt="Screen Shot 2020-05-15 at 2 50 43 PM" src="https://user-images.githubusercontent.com/26111569/82099253-bea8b680-96bb-11ea-8992-83498fad2314.png">
