### PR TITLE
MACF-44: Add support for branch_variable module

### DIFF
--- a/app.js
+++ b/app.js
@@ -453,9 +453,7 @@ define(function(require) {
 				var formattedData = self.formatAccountSettingsData(accountSettingsData),
 					template = $(self.getTemplate({
 						name: 'accountSettings',
-						data: _.merge({
-							showPAssertedIdentity: monster.config.whitelabel.showPAssertedIdentity
-						}, formattedData)
+						data: formattedData
 					})),
 					widgetBlacklist = self.renderBlacklists(template, accountSettingsData);
 
@@ -511,47 +509,59 @@ define(function(require) {
 		},
 
 		formatAccountSettingsData: function(data) {
-			var formattedData = data;
+			var silenceMedia = 'silence_stream://300000',
+				isShoutcast = _
+					.chain(data.account)
+					.get('music_on_hold.media_id')
+					.thru(_.overEvery(
+						_.partial(_.includes, _, '://'),
+						_.partial(_.negate(_.isEqual), silenceMedia)
+					))
+					.value(),
+				preflowCallflows = _
+					.chain(data.callflows)
+					.filter(_.overEvery(
+						{ featurecode: false },
+						_.flow(
+							_.partial(_.get, _, 'numbers'),
+							_.partial(_.negate(_.includes), _, 'no_match')
+						)
+					))
+					.map(function(callflow) {
+						return _.merge({
+							friendlyName: _.get(callflow, 'name', _.toString(callflow.numbers))
+						}, _.pick(callflow, [
+							'id'
+						]));
+					})
+					.sortBy(_.flow(
+						_.partial(_.get, _, 'friendlyName'),
+						_.toLower
+					))
+					.value();
 
-			formattedData.showMediaUploadDisclosure = monster.config.whitelabel.showMediaUploadDisclosure;
-
-			formattedData.silenceMedia = 'silence_stream://300000';
-
-			formattedData.extra = formattedData.extra || {};
-			formattedData.extra.isShoutcast = false;
-
-			formattedData.extra.preflowCallflows = [];
-			_.each(formattedData.callflows, function(callflow) {
-				if (callflow.featurecode === false && callflow.numbers && callflow.numbers.length && callflow.numbers.indexOf('no_match') < 0) {
-					formattedData.extra.preflowCallflows.push({
-						id: callflow.id,
-						friendlyName: callflow.name || callflow.numbers.toString()
-					});
-				}
-			});
-
-			formattedData.extra.preflowCallflows = _.sortBy(formattedData.extra.preflowCallflows, 'friendlyName');
-
-			delete formattedData.callflows;
-
-			if (formattedData.account.hasOwnProperty('music_on_hold') && formattedData.account.music_on_hold.hasOwnProperty('media_id')) {
-				if (formattedData.account.music_on_hold.media_id.indexOf('://') >= 0) {
-					if (formattedData.account.music_on_hold.media_id !== formattedData.silenceMedia) {
-						formattedData.extra.isShoutcast = true;
-					}
-				}
-			}
-
-			if (formattedData.hasOwnProperty('outbound_flags')) {
-				if (formattedData.outbound_flags.hasOwnProperty('dynamic')) {
-					formattedData.outbound_flags.dynamic = formattedData.outbound_flags.dynamic.join(',');
-				}
-				if (formattedData.outbound_flags.hasOwnProperty('static')) {
-					formattedData.outbound_flags.static = formattedData.outbound_flags.static.join(',');
-				}
-			}
-
-			return formattedData;
+			return _.merge({
+				extra: {
+					isShoutcast: isShoutcast,
+					preflowCallflows: preflowCallflows
+				},
+				outbound_flags: _
+					.chain(data.outbound_flags)
+					.pick([
+						'dynamic',
+						'static'
+					])
+					.mapValues(
+						_.partial(_.ary(_.join, 2), _, ',')
+					)
+					.value(),
+				silenceMedia: silenceMedia
+			}, _.pick(monster.config.whitelabel, [
+				'showMediaUploadDisclosure',
+				'showPAssertedIdentity'
+			]), _.omit(data, [
+				'callflows'
+			]));
 		},
 
 		renderBlacklists: function(template, accountSettingsData) {

--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ define(function(require) {
 
 	var appSubmodules = [
 		'blacklist',
+		'branchvariable',
 		'conference',
 		'device',
 		'directory',

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -32,7 +32,13 @@
 		},
 		"branchvariable": {
 			"name": "Branch Variable",
-			"tip": "Enables you to branch based on value of some field inside one of the a call CCVs, user, device or account's document"
+			"tip": "Enables you to branch based on value of some field inside one of the a call CCVs, user, device or account's document",
+			"edit": {
+				"title": "Setup variable to lookup",
+				"scope": "Scope",
+				"id": "Document ID",
+				"variable": "Variable (or path to it)"
+			}
 		},
 		"conference": {
 			"conference": "Conference",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -30,6 +30,10 @@
 			"qubicle_tip": "Route to a queue",
 			"which_queue": "Which queue?"
 		},
+		"branchvariable": {
+			"name": "Branch Variable",
+			"tip": "Enables you to branch based on value of some field inside one of the a call CCVs, user, device or account's document"
+		},
 		"conference": {
 			"conference": "Conference",
 			"conference_tip": "Connect a caller to a Meet-Me conference bridge",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -38,6 +38,12 @@
 				"scope": "Scope",
 				"id": "Document ID",
 				"variable": "Variable (or path to it)"
+			},
+			"editKey": {
+				"action": "Branch on",
+				"default": "Default",
+				"variable": "Specific value",
+				"value": "Value"
 			}
 		},
 		"conference": {

--- a/submodules/branchvariable/branchvariable.js
+++ b/submodules/branchvariable/branchvariable.js
@@ -1,0 +1,31 @@
+define(function(require) {
+	var $ = require('jquery'),
+		_ = require('lodash');
+
+	return {
+		subscribe: {
+			'callflows.fetchActions': 'branchvariableDefineAction'
+		},
+
+		branchvariableDefineAction: function(args) {
+			var self = this,
+				nodes = args.actions;
+
+			$.extend(nodes, {
+				'branch_variable[id=*]': _.merge({
+					icon: 'arrow_sign',
+					category: self.i18n.active().oldCallflows.advanced_cat,
+					module: 'branch_variable',
+					isUsable: 'true',
+					caption: function(node) {
+						return node.getMetadata('variable', '');
+					},
+					edit: console.log
+				}, _.pick(self.i18n.active().callflows.branchvariable, [
+					'name',
+					'tip'
+				]))
+			});
+		}
+	};
+});

--- a/submodules/branchvariable/branchvariable.js
+++ b/submodules/branchvariable/branchvariable.js
@@ -1,6 +1,7 @@
 define(function(require) {
 	var $ = require('jquery'),
-		_ = require('lodash');
+		_ = require('lodash'),
+		monster = require('monster');
 
 	return {
 		subscribe: {
@@ -20,11 +21,104 @@ define(function(require) {
 					caption: function(node) {
 						return node.getMetadata('variable', '');
 					},
-					edit: console.log
+					edit: _.bind(self.branchvariableCallflowEdit, self)
 				}, _.pick(self.i18n.active().callflows.branchvariable, [
 					'name',
 					'tip'
 				]))
+			});
+		},
+
+		branchvariableCallflowEdit: function(node, callback) {
+			var self = this,
+				initTemplate = function(scopeSchema) {
+					return $(self.getTemplate({
+						name: 'callflowEdit',
+						data: {
+							id: node.getMetadata('id', undefined),
+							scope: {
+								selected: node.getMetadata('scope', scopeSchema.default),
+								options: _.sortBy(scopeSchema.enum)
+							},
+							variable: _
+								.chain([
+									node.getMetadata('variable', '')
+								])
+								.flatten()
+								.join('.')
+								.value()
+						},
+						submodule: 'branchvariable'
+					}));
+				},
+				bindEvents = function($popup) {
+					var $form = $popup.find('form');
+
+					monster.ui.validate($form, {
+						rules: {
+							id: {
+								required: true
+							},
+							variable: {
+								required: true
+							}
+						}
+					});
+
+					$popup.find('#scope').on('change', function(event) {
+						event.preventDefault();
+
+						var selected = $(this).val(),
+							shouldShowId = selected === 'doc',
+							$id = $popup.find('#id');
+
+						if (!shouldShowId) {
+							$id.val('');
+						}
+						$id.parents('.control-group').toggle(shouldShowId);
+					});
+
+					$popup.find('#save').on('click', function(event) {
+						event.preventDefault();
+
+						if (!monster.ui.valid($form)) {
+							return;
+						}
+						var formData = monster.ui.getFormData($form.get(0)),
+							id = formData.id;
+
+						node.setMetadata('scope', formData.scope);
+						node.setMetadata('variable', _.split(formData.variable, '.'));
+						node.setMetadata('id', id);
+
+						$popup.dialog('close');
+					});
+				},
+				renderTemplate = _.flow(
+					_.partial(_.get, _, 'properties.scope'),
+					initTemplate,
+					_.bind(monster.ui.dialog, monster.ui, _, {
+						title: self.i18n.active().callflows.branchvariable.name,
+						beforeClose: callback
+					}),
+					bindEvents
+				);
+
+			self.branchvariableCallflowGetData(renderTemplate);
+		},
+
+		branchvariableCallflowGetData: function(next) {
+			var self = this;
+
+			self.callApi({
+				resource: 'schemas.get',
+				data: {
+					schemaId: 'callflows.branch_variable'
+				},
+				success: _.flow(
+					_.partial(_.get, _, 'data'),
+					next
+				)
 			});
 		}
 	};

--- a/submodules/branchvariable/views/callflowEdit.html
+++ b/submodules/branchvariable/views/callflowEdit.html
@@ -1,0 +1,44 @@
+<div class="dialog_popup callflows-port">
+	<h1>
+		{{ i18n.callflows.branchvariable.edit.title }}
+	</h1>
+	<form id="branchvariable_form" class="form-horizontal">
+		<div class="control-group">
+			<label for="scope" class="control-label">
+				{{i18n.callflows.branchvariable.edit.scope}}
+			</label>
+			<div class="controls">
+				<select name="scope" id="scope">
+				{{#select scope.selected}}
+					{{#each scope.options as |option|}}
+						<option value="{{option}}">
+							{{option}}
+						</option>
+					{{/each}}
+				{{/select}}
+			</select>
+			</div>
+		</div>
+		<div class="control-group"{{#compare scope.selected "!==" "doc"}} style="display: none;"{{/compare}}>
+			<label for="id" class="control-label">
+				{{i18n.callflows.branchvariable.edit.id}}
+			</label>
+			<div class="controls">
+				<input type="text" id="id" name="id" value="{{id}}">
+			</div>
+		</div>
+		<div class="control-group">
+			<label for="variable" class="control-label">
+				{{i18n.callflows.branchvariable.edit.variable}}
+			</label>
+			<div class="controls">
+				<input type="text" id="variable" name="variable" value="{{variable}}">
+			</div>
+		</div>
+	</form>
+	<div class="buttons-center">
+		<button id="save" class="monster-button-primary">
+			{{ i18n.save }}
+		</button>
+	</div>
+</div>

--- a/submodules/branchvariable/views/callflowKey.html
+++ b/submodules/branchvariable/views/callflowKey.html
@@ -1,0 +1,34 @@
+<div class="dialog_popup callflows-port">
+	<form id="branchvariable_key_form" class="form-horizontal">
+		<div class="control-group">
+			<label for="action" class="control-label">
+				{{ i18n.callflows.branchvariable.editKey.action }}
+			</label>
+			<div class="controls">
+				<select name="action">
+				{{#select action}}
+					<option value="default">
+						{{ i18n.callflows.branchvariable.editKey.default }}
+					</option>
+					<option value="variable">
+						{{ i18n.callflows.branchvariable.editKey.variable }}
+					</option>
+				{{/select}}
+				</select>
+			</div>
+		</div>
+		<div class="control-group"{{#compare action "===" "default"}} style="display: none;"{{/compare}}>
+			<label for="value" class="control-label">
+				{{i18n.callflows.branchvariable.editKey.value}}
+			</label>
+			<div class="controls">
+				<input type="text" name="value" value="{{value}}">
+			</div>
+		</div>
+	</form>
+	<div class="buttons-center">
+		<button id="save" class="monster-button-primary">
+			{{ i18n.save }}
+		</button>
+	</div>
+</div>


### PR DESCRIPTION
The goal of this PR is to expose the callflow module [branch_variable](https://docs.2600hz.com/supported/applications/callflow/doc/cf_branch_variable/) through the UI.

As an example, we create a callflow playing a text for inbound calls (with the purpose of being used as a preflow and warn callers they're being recorded):
![branch-variable-module](https://user-images.githubusercontent.com/1958193/127203943-2cd1ab03-6701-47e8-97f5-3536662413c5.gif)
