### PR TITLE
[5.0] MACF-60: Remove duplicated branch variable action

### DIFF
--- a/app.js
+++ b/app.js
@@ -1102,25 +1102,37 @@ define(function(require) {
 		},
 
 		construct_action: function(json) {
-			var action = '';
+			var self = this,
+				actionParams = '';
 
 			if ('data' in json) {
 				if ('id' in json.data) {
-					action = 'id=*,';
+					actionParams = 'id=*,';
 				}
 
 				if ('action' in json.data) {
-					action += 'action=' + json.data.action + ',';
+					actionParams += 'action=' + json.data.action + ',';
 				}
 			}
 
-			if (action !== '') {
-				action = '[' + action.replace(/,$/, ']');
+			if (actionParams !== '') {
+				actionParams = '[' + actionParams.replace(/,$/, ']');
 			} else {
-				action = '[]';
+				actionParams = '[]';
 			}
 
-			return json.module + action;
+			var actionWithParamsExists = _
+				.chain(self.actions)
+				.keys()
+				.some(function(actionKey) {
+					return actionKey === json.module + actionParams;
+				})
+				.value(),
+				actionName = actionWithParamsExists
+					? json.module + actionParams
+					: json.module + '[]';
+
+			return actionName;
 		},
 
 		resetFlow: function() {

--- a/app.js
+++ b/app.js
@@ -1121,18 +1121,9 @@ define(function(require) {
 				actionParams = '[]';
 			}
 
-			var actionWithParamsExists = _
-				.chain(self.actions)
-				.keys()
-				.some(function(actionKey) {
-					return actionKey === json.module + actionParams;
-				})
-				.value(),
-				actionName = actionWithParamsExists
-					? json.module + actionParams
-					: json.module + '[]';
-
-			return actionName;
+			return _.has(self.actions, json.module + actionParams)
+				? json.module + actionParams
+				: json.module + '[]';
 		},
 
 		resetFlow: function() {

--- a/submodules/branchvariable/branchvariable.js
+++ b/submodules/branchvariable/branchvariable.js
@@ -10,34 +10,30 @@ define(function(require) {
 
 		branchvariableDefineAction: function(args) {
 			var self = this,
-				nodes = args.actions,
-				buildActionConfig = function() {
-					return _.merge({
-						icon: 'arrow_sign',
-						category: self.i18n.active().oldCallflows.advanced_cat,
-						module: 'branch_variable',
-						isUsable: 'true',
-						caption: function(node) {
-							return node.getMetadata('variable', '');
-						},
-						edit: _.bind(self.branchvariableCallflowEdit, self),
-						key_caption: function(node) {
-							var key = node.key;
-
-							return _.get({
-								_: self.i18n.active().callflows.menu.default_action
-							}, key, key);
-						},
-						key_edit: _.bind(self.branchvariableCallflowKeyEdit, self)
-					}, _.pick(self.i18n.active().callflows.branchvariable, [
-						'name',
-						'tip'
-					]));
-				};
+				nodes = args.actions;
 
 			$.extend(nodes, {
-				'branch_variable[id=*]': buildActionConfig(),
-				'branch_variable[]': buildActionConfig()
+				'branch_variable[]': _.merge({
+					icon: 'arrow_sign',
+					category: self.i18n.active().oldCallflows.advanced_cat,
+					module: 'branch_variable',
+					isUsable: 'true',
+					caption: function(node) {
+						return node.getMetadata('variable', '');
+					},
+					edit: _.bind(self.branchvariableCallflowEdit, self),
+					key_caption: function(node) {
+						var key = node.key;
+
+						return _.get({
+							_: self.i18n.active().callflows.menu.default_action
+						}, key, key);
+					},
+					key_edit: _.bind(self.branchvariableCallflowKeyEdit, self)
+				}, _.pick(self.i18n.active().callflows.branchvariable, [
+					'name',
+					'tip'
+				]))
 			});
 		},
 


### PR DESCRIPTION
Default to parameterless action entry, if the parameter version is not registered in the available callflow actions, to allow to have a single definition for branchvariable module.

![image](https://user-images.githubusercontent.com/893877/152817443-957bce12-bc36-4567-9357-448e3a777120.png)
