### PR TITLE
PROD-199: Check for external numbers capability status

### DIFF
--- a/submodules/user/user.js
+++ b/submodules/user/user.js
@@ -322,20 +322,7 @@ define(function(require) {
 
 			self.random_id = false;
 
-			monster.parallel({
-				cidNumbers: function(next) {
-					self.callApi({
-						resource: 'externalNumbers.list',
-						data: {
-							accountId: self.accountId
-						},
-						success: _.flow(
-							_.partial(_.get, _, 'data'),
-							_.partial(next, null)
-						),
-						error: _.partial(_.ary(next, 2), null, [])
-					});
-				},
+			monster.parallel(_.merge({
 				phoneNumbers: function(next) {
 					self.callApi({
 						resource: 'numbers.listAll',
@@ -459,7 +446,21 @@ define(function(require) {
 						callback(null, defaults);
 					}
 				}
-			},
+			}, monster.util.getCapability('caller_id.external_numbers').isEnable && {
+				cidNumbers: function(next) {
+					self.callApi({
+						resource: 'externalNumbers.list',
+						data: {
+							accountId: self.accountId
+						},
+						success: _.flow(
+							_.partial(_.get, _, 'data'),
+							_.partial(next, null)
+						),
+						error: _.partial(_.ary(next, 2), null, [])
+					});
+				}
+			}),
 			function(err, results) {
 				var render_data = defaults;
 				if (typeof data === 'object' && data.id) {


### PR DESCRIPTION
While implementing PROD-199 (STIR/SHAKEN), one requirement was the ability to toggle the new UX depending on the reachability of its related endpoint (`/external_numbers`).

We then conditionally render that specific UX component based on the presence of data for `/external_numbers`.

This one instance fell through the cracks and was not properly modified to reflect that requirement. I've also double checked every implementation to make sure they were modified correctly.

Behavioral testing can be achieved on the UI by changing the value for `monster.apps.auth.appFlags.capabilities.caller_id.external_numbers.available=true|false` in the console before loading a specific page . When set to `true`, the UI should force end users to select a known CID versus free form selection.