### PR TITLE
[5.1] PROD-169: split failover from forward

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -793,7 +793,7 @@
 			"__version": "4.0",
 			"__comment": "UI-2475: add a failover option to callforward",
 			"failover_callforward": "Failover",
-			"failover_callforward_content": "When checked, if all this user's devices are unregistered, then the system will automatically call-forward (even if the Enable Call-Forward setting isn't enabled)",
+			"failover_callforward_content": "When checked, if all this user's devices are unregistered, then the system will automatically call-forward the call to specified failover number",
 			"__comment": "UI-2921: adding way to impersonate users",
 			"__version": "4.2",
 			"impersonate": "Impersonate",

--- a/submodules/user/views/edit.html
+++ b/submodules/user/views/edit.html
@@ -399,7 +399,7 @@
 							<li>
 								<label>
 									<span rel="popover" data-content="{{ i18n.callflows.user.failover_callforward_content }}">
-										<input type="checkbox" id="call_forward_failover" name="call_forward.failover"{{#if data.call_forward.failover}} checked="checked"{{/if}}/>
+										<input type="checkbox" id="call_failover" name="call_failover.enabled"{{#if data.call_failover.enabled}} checked="checked"{{/if}}/>
 										<span>{{ i18n.callflows.user.failover_callforward }}</span>
 									</span>
 								</label>


### PR DESCRIPTION
Duplicate call forwarding settings into a failover object (account, user, device) and remove ‘failover’ as a call forward option.

The intend is to allow users to be able to change their call forwarding settings without impacting the failover settings and have failover set independently from forward.