### PR TITLE
MACF-64: removing extra 'you' word from header

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1394,7 +1394,7 @@
 	"__comment": "UI-1260: created common control for carrier selection",
 	"__version": "v3.20_s2",
 	"entityManager": {
-		"header": "Click on what you would you like to configure:",
+		"header": "Click on what you would like to configure:",
 		"callflowsTitle": "Callflows",
 		"backButton": "Return to Callflows Home",
 		"accountTitle": "Account Settings",


### PR DESCRIPTION
fixing error on the `header` property value of `entityManager`