### PR TITLE
MACF-76: Fix Time Of Day Increment When Saving

### DIFF
--- a/submodules/timeofday/timeofday.js
+++ b/submodules/timeofday/timeofday.js
@@ -419,7 +419,7 @@ define(function(require) {
 			if (form_data.start_date === '') {
 				delete form_data.start_date;
 			} else {
-				form_data.start_date = monster.util.validateEndOrBeginingOfGregorianDay(form_data.start_date, 'UTC');
+				form_data.start_date = monster.util.dateToBeginningOfGregorianDay(form_data.start_date, monster.util.getCurrentTimeZone());
 			}
 
 			form_data.time_window_start = parseInt(monster.util.timeToSeconds(timeStart));

--- a/submodules/timeofday/timeofday.js
+++ b/submodules/timeofday/timeofday.js
@@ -419,7 +419,7 @@ define(function(require) {
 			if (form_data.start_date === '') {
 				delete form_data.start_date;
 			} else {
-				form_data.start_date = monster.util.dateToEndOfGregorianDay(form_data.start_date, 'UTC');
+				form_data.start_date = monster.util.validateEndOrBeginingOfGregorianDay(form_data.start_date, 'UTC');
 			}
 
 			form_data.time_window_start = parseInt(monster.util.timeToSeconds(timeStart));


### PR DESCRIPTION
changing `dateToEndOfGregorianDay`  to `dateToBeginningOfGregorianDay` and passing `monster.util.getCurrentTimeZone()` ass second parameter to solve the issue of timezone convertions adding or reducing a day from the `time of day` `start date`.