### PR TITLE
[5.2] MACF-75: Improve edit view for holidays at Time Of Day

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -576,6 +576,8 @@
 			"weeks": "week(s)",
 			"on": "On:",
 			"select_which_days": "Select which days to apply this rule",
+			"date": "Date",
+			"date_data_content": "Select the date of this rule",
 			"start_date": "Start Date",
 			"start_date_data_content": "Select the starting date of this rule",
 			"end_date": "End Date",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -578,6 +578,8 @@
 			"select_which_days": "Select which days to apply this rule",
 			"start_date": "Start Date",
 			"start_date_data_content": "Select the starting date of this rule",
+			"end_date": "End Date",
+			"end_date_data_content": "Select the ending date of this rule",
 			"enabled": "Enabled",
 			"enabled_data_content": "Select when this rule should be enabled",
 			"enabled_based_on_time": "Based on time",

--- a/submodules/timeofday/timeofday.js
+++ b/submodules/timeofday/timeofday.js
@@ -172,6 +172,16 @@ define(function(require) {
 					var renderData = $.extend(true, defaults, oldFormatData);
 
 					renderData.field_data.isAllDay = isAllDay;
+					renderData.extra.holidayType = renderData.data.showSave || _data.type !== 'main_holidays'
+						? null
+						: _.has(_data, 'ordinal')
+							? 'advanced'
+							: _.has(_data, 'viewData') || _.chain(_data).get('days', []).size().value() > 1
+								? 'range'
+								: 'single';
+					renderData.data.cycle = renderData.extra.holidayType === 'single'
+						? 'date'
+						: renderData.data.cycle;
 
 					self.timeofdayRender(renderData, target, callbacks);
 
@@ -623,7 +633,7 @@ define(function(require) {
 							submodule: 'timeofday'
 						}));
 
-						timezone.populateDropdown($('#timezone_selector', popup_html), node.getMetadata('timezone') || 'inherit', {inherit: self.i18n.active().defaultTimezone});
+						timezone.populateDropdown($('#timezone_selector', popup_html), node.getMetadata('timezone') || 'inherit', { inherit: self.i18n.active().defaultTimezone });
 
 						$('#add', popup_html).click(function() {
 							var timezone = $('#timezone_selector', popup_html).val();

--- a/submodules/timeofday/timeofday.js
+++ b/submodules/timeofday/timeofday.js
@@ -161,18 +161,17 @@ define(function(require) {
 					}
 				};
 
-			if (typeof data === 'object' && data.id) {
-				self.temporalRuleGet(data.id, function(_data, status) {
-					var oldFormatData = { data: _data };
+			if (_.isPlainObject(data) && data.id) {
+				self.temporalRuleGet(data.id, function(_data) {
+					var oldFormatData = { data: _data },
+						isAllDay = _.get(_data, 'time_window_start', 0) === 0 && _.get(_data, 'time_window_stop', 86400) === 86400;
 
 					self.timeofdayMigrateData(oldFormatData);
 					self.timeofdayFormatData(oldFormatData);
 
 					var renderData = $.extend(true, defaults, oldFormatData);
 
-					if (renderData.data.time_window_start === 0 && renderData.data.time_window_stop === 86400) {
-						renderData.field_data.isAllDay = true;
-					}
+					renderData.field_data.isAllDay = isAllDay;
 
 					self.timeofdayRender(renderData, target, callbacks);
 
@@ -222,6 +221,7 @@ define(function(require) {
 			self.winkstartTabs(timeofday_html);
 
 			monster.ui.datepicker(timeofday_html.find('#start_date'));
+			monster.ui.datepicker(timeofday_html.find('#end_date'));
 			monster.ui.timepicker(timeofday_html.find('.timepicker'), {
 				step: 5
 			});

--- a/submodules/timeofday/timeofday.js
+++ b/submodules/timeofday/timeofday.js
@@ -181,10 +181,7 @@ define(function(require) {
 							: _.has(_data, 'viewData') || _.chain(_data).get('days', []).size().value() > 1
 								? 'range'
 								: 'single';
-					renderData.data.cycle = renderData.extra.holidayType === 'single'
-						? 'date'
-						: renderData.data.cycle;
-					renderData.field_data.hideCycle = _.includes(['range', 'advanced'], renderData.extra.holidayType) && !_.isNil(renderData.data.end_date);
+					renderData.field_data.hideCycle = !_.isNull(renderData.extra.holidayType) && !_.isNil(renderData.data.end_date);
 
 					self.timeofdayRender(renderData, target, callbacks);
 

--- a/submodules/timeofday/timeofday.js
+++ b/submodules/timeofday/timeofday.js
@@ -157,7 +157,9 @@ define(function(require) {
 							{ id: 12, value: 'December' }
 						],
 
-						isAllDay: false
+						isAllDay: false,
+
+						hideCycle: false
 					}
 				};
 
@@ -182,6 +184,7 @@ define(function(require) {
 					renderData.data.cycle = renderData.extra.holidayType === 'single'
 						? 'date'
 						: renderData.data.cycle;
+					renderData.field_data.hideCycle = _.includes(['range', 'advanced'], renderData.extra.holidayType) && !_.isNil(renderData.data.end_date);
 
 					self.timeofdayRender(renderData, target, callbacks);
 

--- a/submodules/timeofday/views/callflowEdit.html
+++ b/submodules/timeofday/views/callflowEdit.html
@@ -26,6 +26,7 @@
 						</div>
 					</div>
 
+				{{#unless field_data.hideCycle}}
 					<div class="clearfix" id="repeats">
 						<label for="cycle">{{ i18n.callflows.timeofday.repeats }}</label>
 						<div class="input">
@@ -38,6 +39,7 @@
 							</select>
 						</div>
 					</div>
+				{{/unless}}
 
 					<div class="clearfix" id="every">
 						<label>{{ i18n.callflows.timeofday.every }}</label>

--- a/submodules/timeofday/views/callflowEdit.html
+++ b/submodules/timeofday/views/callflowEdit.html
@@ -106,6 +106,15 @@
 						</div>
 					</div>
 
+				{{#if data.end_date}}
+					<div class="clearfix">
+						<label for="day">{{ i18n.callflows.timeofday.end_date }}</label>
+						<div class="input">
+							<input class="span4" id="end_date" name="end_date" type="text" placeholder="" value="{{ toFriendlyDate data.end_date "date"}}" rel="popover" data-content="{{ i18n.callflows.timeofday.end_date_data_content }}"{{#unless data.showSave}} disabled{{/unless}} />
+						</div>
+					</div>
+				{{/if}}
+
 					<div class="clearfix time-wrapper-field">
 						<label for="time">{{ i18n.callflows.timeofday.time }}</label>
 						<div class="input time-wrapper{{#if field_data.isAllDay}} hidden{{/if}}">

--- a/submodules/timeofday/views/callflowEdit.html
+++ b/submodules/timeofday/views/callflowEdit.html
@@ -99,21 +99,32 @@
 						</div>
 					</div>
 
+				{{#compare extra.holidayType "!==" "single"}}
 					<div class="clearfix">
 						<label for="day">{{ i18n.callflows.timeofday.start_date }}</label>
 						<div class="input">
 							<input class="span4" id="start_date" name="start_date" type="text" placeholder="" value="{{ toFriendlyDate data.start_date "date"}}" rel="popover" data-content="{{ i18n.callflows.timeofday.start_date_data_content }}"{{#unless data.showSave}} disabled{{/unless}} />
 						</div>
 					</div>
+				{{/compare}}
 
-				{{#if data.end_date}}
+			{{#if data.end_date}}
+				{{#compare extra.holidayType "===" "single"}}
+					<div class="clearfix">
+						<label for="day">{{ i18n.callflows.timeofday.date }}</label>
+						<div class="input">
+							<input class="span4" id="end_date" name="end_date" type="text" placeholder="" value="{{ toFriendlyDate data.end_date "date"}}" rel="popover" data-content="{{ i18n.callflows.timeofday.date_data_content }}"{{#unless data.showSave}} disabled{{/unless}} />
+						</div>
+					</div>
+				{{else}}
 					<div class="clearfix">
 						<label for="day">{{ i18n.callflows.timeofday.end_date }}</label>
 						<div class="input">
 							<input class="span4" id="end_date" name="end_date" type="text" placeholder="" value="{{ toFriendlyDate data.end_date "date"}}" rel="popover" data-content="{{ i18n.callflows.timeofday.end_date_data_content }}"{{#unless data.showSave}} disabled{{/unless}} />
 						</div>
 					</div>
-				{{/if}}
+				{{/compare}}
+			{{/if}}
 
 					<div class="clearfix time-wrapper-field">
 						<label for="time">{{ i18n.callflows.timeofday.time }}</label>

--- a/submodules/timeofday/views/callflowEdit.html
+++ b/submodules/timeofday/views/callflowEdit.html
@@ -22,14 +22,14 @@
 					<div class="clearfix">
 						<label for="name">{{ i18n.callflows.timeofday.name }}</label>
 						<div class="input">
-							<input class="span4" id="name" name="name" type="text" placeholder="{{ i18n.callflows.timeofday.name }}" value="{{ data.name }}" rel="popover" data-content="{{ i18n.callflows.timeofday.name_data_content }}" required/>
+							<input class="span4" id="name" name="name" type="text" placeholder="{{ i18n.callflows.timeofday.name }}" value="{{ data.name }}" rel="popover" data-content="{{ i18n.callflows.timeofday.name_data_content }}" required{{#unless data.showSave}} disabled{{/unless}} />
 						</div>
 					</div>
 
 					<div class="clearfix" id="repeats">
 						<label for="cycle">{{ i18n.callflows.timeofday.repeats }}</label>
 						<div class="input">
-							<select name="cycle" id="cycle" class="input-medium" rel="popover" data-content="{{ i18n.callflows.timeofday.repeats_data_content }}">
+							<select name="cycle" id="cycle" class="input-medium" rel="popover" data-content="{{ i18n.callflows.timeofday.repeats_data_content }}"{{#unless data.showSave}} disabled{{/unless}}>
 								{{#select data.cycle}}
 									{{#each field_data.cycle}}
 										<option id="{{ id }}" value="{{ id }}">{{ value }}</option>
@@ -43,7 +43,7 @@
 						<label>{{ i18n.callflows.timeofday.every }}</label>
 						<div class="input" >
 							<div id="yearly_every">
-								<select name="month" id="month" class="input-medium" rel="popover" data-content="{{ i18n.callflows.timeofday.every_data_content }}">
+								<select name="month" id="month" class="input-medium" rel="popover" data-content="{{ i18n.callflows.timeofday.every_data_content }}"{{#unless data.showSave}} disabled{{/unless}}>
 									{{#select data.month}}
 										{{#each field_data.months}}
 											<option value="{{ id }}">{{ value }}</option>
@@ -53,10 +53,10 @@
 							</div>
 
 							<span id="monthly_every">
-								<input class="span1" id="interval_month" name="interval" type="text" placeholder="1" value="{{ data.interval }}" rel="popover" data-content=""/>&nbsp;{{ i18n.callflows.timeofday.months }}
+								<input class="span1" id="interval_month" name="interval" type="text" placeholder="1" value="{{ data.interval }}" rel="popover" data-content=""{{#unless data.showSave}} disabled{{/unless}} />&nbsp;{{ i18n.callflows.timeofday.months }}
 							</span>
 							<span id="weekly_every">
-								<input class="span1" id="interval_week" name="interval" type="text" placeholder="1" value="{{ data.interval }}" rel="popover" data-content=""/>&nbsp;{{ i18n.callflows.timeofday.weeks }}
+								<input class="span1" id="interval_week" name="interval" type="text" placeholder="1" value="{{ data.interval }}" rel="popover" data-content=""{{#unless data.showSave}} disabled{{/unless}} />&nbsp;{{ i18n.callflows.timeofday.weeks }}
 							</span>
 						</div>
 					</div>
@@ -64,7 +64,7 @@
 					<div class="clearfix" id="on">
 						<label>{{ i18n.callflows.timeofday.on }}</label>
 						<div class="input">
-							<select name="ordinal" id="ordinal" class="input-medium" rel="popover" data-content="">
+							<select name="ordinal" id="ordinal" class="input-medium" rel="popover" data-content=""{{#unless data.showSave}} disabled{{/unless}}>
 								{{#select data.ordinal}}
 									{{#each field_data.ordinals}}
 										<option value="{{ id }}">{{ value }}</option>
@@ -73,7 +73,7 @@
 							</select>
 
 							<span id="weekdays">
-								<select id="wday" name="weekday" class="medium">
+								<select id="wday" name="weekday" class="medium"{{#unless data.showSave}} disabled{{/unless}}>
 									{{#select data.wdays.[0]}}
 										{{#each field_data.wdays}}
 											<option value="{{ @key }}">{{ this.friendlyName }}</option>
@@ -88,7 +88,7 @@
 								{{/each}}
 							</span>
 
-							<select id="specific_day" name="days[0]" class="input-medium">
+							<select id="specific_day" name="days[0]" class="input-medium"{{#unless data.showSave}} disabled{{/unless}}>
 								{{#select data.days.[0]}}
 									{{#each field_data.day}}
 										{{ this }}
@@ -102,7 +102,7 @@
 					<div class="clearfix">
 						<label for="day">{{ i18n.callflows.timeofday.start_date }}</label>
 						<div class="input">
-							<input class="span4" id="start_date" name="start_date" type="text" placeholder="" value="{{ toFriendlyDate data.start_date "date"}}" rel="popover" data-content="{{ i18n.callflows.timeofday.start_date_data_content }}"/>
+							<input class="span4" id="start_date" name="start_date" type="text" placeholder="" value="{{ toFriendlyDate data.start_date "date"}}" rel="popover" data-content="{{ i18n.callflows.timeofday.start_date_data_content }}"{{#unless data.showSave}} disabled{{/unless}} />
 						</div>
 					</div>
 
@@ -118,13 +118,13 @@
 					<div class="clearfix time-wrapper-field">
 						<label for="time">{{ i18n.callflows.timeofday.time }}</label>
 						<div class="input time-wrapper{{#if field_data.isAllDay}} hidden{{/if}}">
-							<input class="from-hour timepicker" type="text" name="extra.timeofday.from" value="{{ extra.timeStart }}">
+							<input class="from-hour timepicker" type="text" name="extra.timeofday.from" value="{{ extra.timeStart }}"{{#unless data.showSave}} disabled{{/unless}} />
 							{{ i18n.callflows.timeofday.to }}
-							<input class="to-hour timepicker" type="text" name="extra.timeofday.to" value="{{ extra.timeStop  }}">
+							<input class="to-hour timepicker" type="text" name="extra.timeofday.to" value="{{ extra.timeStop  }}"{{#unless data.showSave}} disabled{{/unless}} />
 						</div>
 						<div class="checkbox-container">
 							{{#monsterCheckbox i18n.callflows.timeofday.allDay }}
-								<input id="all_day_checkbox" type="checkbox" name="extra.allDay"{{#if field_data.isAllDay}} checked{{/if}}></input>
+								<input id="all_day_checkbox" type="checkbox" name="extra.allDay"{{#if field_data.isAllDay}} checked{{/if}}{{#unless data.showSave}} disabled{{/unless}} />
 							{{/monsterCheckbox}}
 						</div>
 					</div>
@@ -132,7 +132,7 @@
 					<div class="clearfix">
 						<label for="day">{{ i18n.callflows.timeofday.enabled }}</label>
 						<div class="input">
-							<select name="enabled" id="enabled" class="input-medium" rel="popover" data-content="{{ i18n.callflows.timeofday.enabled_data_content }}">
+							<select name="enabled" id="enabled" class="input-medium" rel="popover" data-content="{{ i18n.callflows.timeofday.enabled_data_content }}"{{#unless data.showSave}} disabled{{/unless}}>
 								<option value="">{{ i18n.callflows.timeofday.enabled_based_on_time }}</option>
 								<option value="true"{{#if data.enabled}} selected{{/if}}>{{ i18n.callflows.timeofday.enabled_forced_on }}</option>
 								<option value="false"{{#compare data.enabled "===" false}} selected{{/compare}}>{{ i18n.callflows.timeofday.enabled_forced_off }}</option>

--- a/submodules/timeofday/views/callflowEdit.html
+++ b/submodules/timeofday/views/callflowEdit.html
@@ -101,32 +101,21 @@
 						</div>
 					</div>
 
-				{{#compare extra.holidayType "!==" "single"}}
 					<div class="clearfix">
 						<label for="day">{{ i18n.callflows.timeofday.start_date }}</label>
 						<div class="input">
 							<input class="span4" id="start_date" name="start_date" type="text" placeholder="" value="{{ toFriendlyDate data.start_date "date"}}" rel="popover" data-content="{{ i18n.callflows.timeofday.start_date_data_content }}"{{#unless data.showSave}} disabled{{/unless}} />
 						</div>
 					</div>
-				{{/compare}}
 
-			{{#if data.end_date}}
-				{{#compare extra.holidayType "===" "single"}}
-					<div class="clearfix">
-						<label for="day">{{ i18n.callflows.timeofday.date }}</label>
-						<div class="input">
-							<input class="span4" id="end_date" name="end_date" type="text" placeholder="" value="{{ toFriendlyDate data.end_date "date"}}" rel="popover" data-content="{{ i18n.callflows.timeofday.date_data_content }}"{{#unless data.showSave}} disabled{{/unless}} />
-						</div>
-					</div>
-				{{else}}
+				{{#if data.end_date}}
 					<div class="clearfix">
 						<label for="day">{{ i18n.callflows.timeofday.end_date }}</label>
 						<div class="input">
 							<input class="span4" id="end_date" name="end_date" type="text" placeholder="" value="{{ toFriendlyDate data.end_date "date"}}" rel="popover" data-content="{{ i18n.callflows.timeofday.end_date_data_content }}"{{#unless data.showSave}} disabled{{/unless}} />
 						</div>
 					</div>
-				{{/compare}}
-			{{/if}}
+				{{/if}}
 
 					<div class="clearfix time-wrapper-field">
 						<label for="time">{{ i18n.callflows.timeofday.time }}</label>


### PR DESCRIPTION
The improvements at the edit page for Time Of Day include the following:
* Display the end date form field, if the value is present.
* Mark the entry as "All day", if no time is specified.
* Disable all the form fields to prevent user input, if the save button is hidden.
* Hide repeat cycle field for non-recurring holidays.