### PR TITLE
MUDA-18: Show meta device as active

### DIFF
--- a/app.js
+++ b/app.js
@@ -2185,6 +2185,11 @@ define(function(require) {
 		},
 
 		isDeviceCallable: function(device) {
+			// TODO: this validation should be removed once the backend returns the actual meta device status.
+			if (device.device_type === 'meta') {
+				return true;
+			}
+
 			return _.every([
 				device.enabled,
 				device.registrable ? device.registered : true


### PR DESCRIPTION
<img width="301" alt="image" src="https://github.com/2600hz/monster-ui-callflows/assets/10261798/b4882127-00ca-43fb-9058-1f2a7200b3b6">
