### PR TITLE
[5.1] MACF-81: Revert 'UI-2948: set ignore completed elsewhere to true by default

### DIFF
--- a/submodules/device/device.js
+++ b/submodules/device/device.js
@@ -85,7 +85,6 @@ define(function(require) {
 							emergency: {}
 						},
 						ringtones: {},
-						ignore_completed_elsewhere: true,
 						call_restriction: { closed_groups: 'inherit' },
 						media: {
 							secure_rtp: 'none',


### PR DESCRIPTION
https://github.com/2600hz/kazoo/blob/master/applications/crossbar/doc/devices.md

Key | Description | Type | Default | Required | Support Level
--- | ----------- | ---- | ------- | -------- | -------------
`sip.ignore_completed_elsewhere` | When set to false the phone should not consider ring group calls answered elsewhere as missed | `boolean()` |   | `false` |