### PR TITLE
[5.3] MSTR-275: do not require sub module, let core handle it

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,30 +3,6 @@ define(function(require) {
 		_ = require('lodash'),
 		monster = require('monster');
 
-	var appSubmodules = [
-		'blacklist',
-		'branchvariable',
-		'conference',
-		'device',
-		'directory',
-		'faxbox',
-		'featurecodes',
-		'groups',
-		'media',
-		'menu',
-		'misc',
-		'qubicle',
-		'resource',
-		'temporalset',
-		'timeofday',
-		'user',
-		'vmbox'
-	];
-
-	require(_.map(appSubmodules, function(name) {
-		return './submodules/' + name + '/' + name;
-	}));
-
 	var app = {
 		name: 'callflows',
 
@@ -43,7 +19,25 @@ define(function(require) {
 		// Define the events available for other apps
 		subscribe: {},
 
-		subModules: appSubmodules,
+		subModules: [
+			'blacklist',
+			'branchvariable',
+			'conference',
+			'device',
+			'directory',
+			'faxbox',
+			'featurecodes',
+			'groups',
+			'media',
+			'menu',
+			'misc',
+			'qubicle',
+			'resource',
+			'temporalset',
+			'timeofday',
+			'user',
+			'vmbox'
+		],
 
 		appFlags: {
 			flow: {},


### PR DESCRIPTION
If the app assets is loading from external `source_url`, if the app tries to require its sub modules directly it will fail and the app won't load at all.

Changing the module name to its external `source_url` as what Monster UI core was previously doing won't always work in case the sub modules were small enough and optimized away in a single file as `app.js`. This has been observed with `branding` and `call-recording` apps so far.

Instead we can explicitly config the paths for sub module and its external source url for `requirejs` to load it, if it is not already optimized in the `app.js`.

Without this change, because `app.js` is requiring the submodules, this URL will be used instead of external source_url:

```
http://{monster_ui_url}/apps/:appname/submodules/{submodule}/{submodule}.js
```

`requireSubModule` from `monster.apps.js` will require all submodules defined on the app and can adds external `source_url` of the sub module in requirejs config so the correct URL will be used for fetch if it is needed:

```
http://{app_metadata.source_url}/submodules/{submodule}/{submodule}.js
```

Read more: https://requirejs.org/docs/jquery.html#modulename