### PR TITLE
[5.5] MSPB-394: Fix callflow race condition and add dirty tracking

### DIFF
--- a/style/app.scss
+++ b/style/app.scss
@@ -1737,3 +1737,15 @@
 .media-edit-callflow-popup #edit_link.active {
 	display: block;
 }
+
+/* Disabled states for race condition protection */
+#callflow_container .left-bar-container .list.disabled,
+#callflow_container .left-bar-container .list-add.disabled,
+#callflow_container .entity-edition .list-container .list.disabled,
+#callflow_container .entity-edition .list-add.disabled,
+#callflow_container .buttons .save.disabled,
+#callflow_container .entity-edition [class*="-save"].disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+	pointer-events: none;
+}

--- a/submodules/blacklist/blacklist.js
+++ b/submodules/blacklist/blacklist.js
@@ -73,6 +73,10 @@ define(function(require) {
 					(args.target)
 						.empty()
 						.append(template);
+
+					if (typeof args.callbacks.after_render === 'function') {
+						args.callbacks.after_render();
+					}
 				};
 
 			if (args.data.id) {

--- a/submodules/groups/groups.js
+++ b/submodules/groups/groups.js
@@ -167,6 +167,10 @@ define(function(require) {
 			(target)
 				.empty()
 				.append(groups_html);
+
+			if (typeof callbacks.after_render === 'function') {
+				callbacks.after_render();
+			}
 		},
 
 		// Added for the subscribed event to avoid refactoring mediaEdit


### PR DESCRIPTION
Fix race condition in callflows app where rapidly clicking between callflows causes data to be saved to the wrong callflow, resulting in data corruption.

### Changes

- **Race Condition Protection**: Disable callflow/entity list during load and save operations, validate API responses match requested IDs, bind save operations to the loaded callflow ID
- **Dirty Tracking**: Disable save button until user makes changes, re-disable when changes are undone
- **CSS**: Add disabled state styles for lists and buttons
- **Submodules**: Add missing after_render callbacks to blacklist and groups

### Test Plan

- [x] Click rapidly between callflows, verify correct callflow is saved
- [x] Verify callflow list is disabled during load
- [x] Verify callflow list is disabled during save
- [x] Verify save button is disabled until changes are made
- [x] Verify save button re-disables when changes are undone
- [x] Test entity sections (devices, users, media, etc.) for same behavior
- [x] Test on slow connection (throttled network)

## Future Improvements

These improvements could enhance the fix but are not required for initial implementation:

1. **Visual loading indicator** - Add spinner overlay during load/save operations
2. **User feedback on blocked clicks** - Show toast message when clicking disabled list
3. **Timeout protection** - Reset flags after X seconds if API hangs to prevent stuck UI
4. **Unsaved changes warning** - Prompt user before loading new item with unsaved changes
