### PR TITLE
MSPB-404: Fix vmbox email recipients dirty tracking

### DIFF
--- a/submodules/vmbox/views/edit.html
+++ b/submodules/vmbox/views/edit.html
@@ -426,7 +426,7 @@
 					<div class="clearfix">
 						<label for="timezone">{{ i18n.callflows.vmbox.recipients.title }}</label>
 						<div class="input">
-							<textarea id="recipients_list" placeholder="{{ i18n.callflows.vmbox.recipients.placeholder }}">
+							<textarea id="recipients_list" name="recipients_list" placeholder="{{ i18n.callflows.vmbox.recipients.placeholder }}">
 								{{data.extra.recipients}}
 							</textarea>
 						</div>


### PR DESCRIPTION
### Summary
- Fix vmbox email recipients field not triggering dirty tracking after `MSPB-394` changes
- The `recipients_list` textarea was missing a `name` attribute, causing `serializeForm()` to skip it
- Save button remained permanently disabled when only the email recipients field was changed

### Changes
- Add `name="recipients_list"` to the `<textarea id="recipients_list">` element
- This allows the dirty tracking system (`serializeForm` in `app.js`) to detect changes to this field

### Test Plan
- [x] Open Callflows app, open or create a callflow
- [x] Add a Voicemail node, click to edit the voicemail box
- [x] Modify the email recipients field
- [x] Verify the save button becomes enabled
- [x] Save and verify recipients are persisted correctly
- [x] Verify other vmbox form fields still trigger dirty tracking correctly

### Ticket
MSPB-404: Vmbox email recipients dirty tracking broken (subtask of `MSPB-394`)
https://oomacorp.atlassian.net/browse/MSPB-394