### PR TITLE
[5.4] MACF-95: Add new 'Extended Address' field for Users and Devices in Callflows (#283)

### DIFF
--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -263,6 +263,11 @@
 			"edit_user_options": "Benutzeroptionen bearbeiten",
 			"add_user": "Fügen Sie einen Benutzer hinzu",
 			"caller_id_number_data_content": "Wenn die Anrufer-ID-Nummer des Gerätes und die des Benutzers nicht festgelegt sind, legen Sie die Anrufer-ID-Nummer dieses Benutzers für hausinterne Anrufe fest.",
+			"e911": {
+				"extended_address": "Extended Address",
+                                "extended_address_placeholder": "Room 123",
+                                "extended_address_data_content": "Define the Caller ID Extended Address of this User for Emergency Calls (max. 32 chars)."
+			},
 			"keep_caller_id_data_content": "Wenn aktiviert, wird die Caller-ID des Anrufers verwendet.",
 			"email": "E-Mail",
 			"add_user_label": "Benutzer hinzufügen",
@@ -435,6 +440,11 @@
 			"caller_id_number": "Anrufer-ID-Nummer",
 			"caller_id_number_data_content2": "Legen Sie die Anrufer-ID-Nummer dieses Gerätes für ausgehende Anrufe fest.",
 			"caller_id_number_data_content3": "Legen Sie die Anrufer-ID-Nummer dieses Gerätes für Notrufe fest.",
+			"e911": {
+				"extended_address": "Extended Address",
+				"extended_address_placeholder": "Room 123",
+				"extended_address_data_content": "Define the Caller ID Extended Address of this Device for Emergency Calls (max. 32 chars)."
+			},			
 			"seconds": "Sekunden",
 			"__comment": "UI-2135: Eine leere Option für SIP-Gerätemarken hinzufügen",
 			"peer_to_peer_audio_data_content": "Wählen Sie aus",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -186,6 +186,11 @@
 			"outbound_calls": "Outbound Calls",
 			"caller_id_name_data_content2": "Define the Caller ID Name of this Device for Outbound Calls (max. 30 chars).",
 			"caller_id_number_data_content2": "Define the Caller ID Number of this Device for Outbound Calls.",
+			"e911": {
+				"extended_address": "Extended Address",
+				"extended_address_placeholder": "Room 123",
+				"extended_address_data_content": "Define the Caller ID Extended Address of this Device for Emergency Calls (max. 32 chars)."
+			},			
 			"emergency": "Emergency",
 			"caller_id_name_data_content3": "Define the Caller ID Name of this Device for Emergency Calls (max. 30 chars).",
 			"caller_id_number_data_content3": "Define the Caller ID Number of this Device for Emergency Calls.",
@@ -700,6 +705,11 @@
 			"caller_id_name_data_content": "Define the Caller ID Name of this User for In-House Calls (max. 30 chars). If the Caller ID Name of the device and of the user is not set, this Caller ID Name will be used.",
 			"caller_id_number": "Caller ID Number",
 			"caller_id_number_data_content": "Define the Caller ID Number of this User for In-House Calls. If the Caller ID Number of the device and of the user is not set, this Caller ID Number will be used.",
+			"e911": {
+				"extended_address": "Extended Address",
+				"extended_address_placeholder": "Room 123",
+				"extended_address_data_content": "Define the Caller ID Extended Address of this User for Emergency Calls (max. 32 chars)."
+			},
 			"outbound_calls": "Outbound Calls",
 			"caller_id_name_data_content2": "Define the Caller ID Name of this User for Outbound Calls (max. 30 chars). If the Caller ID Name of the device and of the user is not set, this Caller ID Name will be used.",
 			"caller_id_number_data_content2": "Define the Caller ID Number of this User for Outbound Calls. If the Caller ID Number of the device and of the user is not set, this Caller ID Number will be used.",

--- a/submodules/device/device.css
+++ b/submodules/device/device.css
@@ -101,6 +101,16 @@
 	display: block;
 }
 
+.callflows-port #device-form .caller-id-emergency-target {
+	margin-bottom: 10px;
+}
+
+.callflows-port #device-form {
+	.chosen-container, .chosen-drop, #owner_id {
+		width: 224px !important;
+	}
+}
+
 .callflows-port .pill-content{
 	margin-bottom: 20px;
 }

--- a/submodules/device/device.js
+++ b/submodules/device/device.js
@@ -501,7 +501,8 @@ define(function(require) {
 					rules: {
 						'caller_id.asserted.name': { regex: /^[0-9A-Za-z ,]{0,30}$/ },
 						'caller_id.asserted.number': { phoneNumber: true },
-						'caller_id.asserted.realm': { realm: true }
+						'caller_id.asserted.realm': { realm: true },
+						'e911.street_address_extended': { maxlength: 32 }
 					},
 					messages: {
 						'caller_id.asserted.name': { regex: i18n.callflows.device.validation.caller_id.name },

--- a/submodules/device/views/device-ata.html
+++ b/submodules/device/views/device-ata.html
@@ -137,6 +137,13 @@
 						</div>
 					{{/if}}
 					</div>
+
+					<div class="clearfix">
+						<label for="e911_street_address_extended">{{ i18n.callflows.device.e911.extended_address }}</label>
+						<div class="input">
+							<input class="span4" id="e911_street_address_extended" name="e911.street_address_extended" type="text" placeholder="{{ i18n.callflows.user.e911.extended_address_placeholder }}" value="{{data.e911.street_address_extended}}" rel="popover" data-content="{{ i18n.callflows.device.e911.extended_address_data_content }}" />
+						</div>
+					</div>
 					<hr />
 
 				{{#if showPAssertedIdentity}}

--- a/submodules/device/views/device-fax.html
+++ b/submodules/device/views/device-fax.html
@@ -152,6 +152,13 @@
 						</div>
 					{{/if}}
 					</div>
+
+					<div class="clearfix">
+						<label for="e911_street_address_extended">{{ i18n.callflows.device.e911.extended_address }}</label>
+						<div class="input">
+							<input class="span4" id="e911_street_address_extended" name="e911.street_address_extended" type="text" placeholder="{{ i18n.callflows.user.e911.extended_address_placeholder }}" value="{{data.e911.street_address_extended}}" rel="popover" data-content="{{ i18n.callflows.device.e911.extended_address_data_content }}" />
+						</div>
+					</div>
 					<hr />
 
 				{{#if showPAssertedIdentity}}

--- a/submodules/device/views/device-mobile.html
+++ b/submodules/device/views/device-mobile.html
@@ -139,6 +139,13 @@
 						</div>
 					{{/if}}
 					</div>
+
+					<div class="clearfix">
+						<label for="e911_street_address_extended">{{ i18n.callflows.device.e911.extended_address }}</label>
+						<div class="input">
+							<input class="span4" id="e911_street_address_extended" name="e911.street_address_extended" type="text" placeholder="{{ i18n.callflows.user.e911.extended_address_placeholder }}" value="{{data.e911.street_address_extended}}" rel="popover" data-content="{{ i18n.callflows.device.e911.extended_address_data_content }}" />
+						</div>
+					</div>
 					<hr />
 
 				{{#if showPAssertedIdentity}}

--- a/submodules/device/views/device-sip_device.html
+++ b/submodules/device/views/device-sip_device.html
@@ -181,6 +181,13 @@
 						</div>
 					{{/if}}
 					</div>
+
+					<div class="clearfix">
+						<label for="e911_street_address_extended">{{ i18n.callflows.device.e911.extended_address }}</label>
+						<div class="input">
+							<input class="span4" id="e911_street_address_extended" name="e911.street_address_extended" type="text" placeholder="{{ i18n.callflows.user.e911.extended_address_placeholder }}" value="{{data.e911.street_address_extended}}" rel="popover" data-content="{{ i18n.callflows.device.e911.extended_address_data_content }}" />
+						</div>
+					</div>
 					<hr />
 
 				{{#if showPAssertedIdentity}}

--- a/submodules/device/views/device-softphone.html
+++ b/submodules/device/views/device-softphone.html
@@ -154,6 +154,13 @@
 						</div>
 					{{/if}}
 					</div>
+
+					<div class="clearfix">
+						<label for="e911_street_address_extended">{{ i18n.callflows.device.e911.extended_address }}</label>
+						<div class="input">
+							<input class="span4" id="e911_street_address_extended" name="e911.street_address_extended" type="text" placeholder="{{ i18n.callflows.user.e911.extended_address_placeholder }}" value="{{data.e911.street_address_extended}}" rel="popover" data-content="{{ i18n.callflows.device.e911.extended_address_data_content }}" />
+						</div>
+					</div>
 					<hr />
 
 				{{#if showPAssertedIdentity}}

--- a/submodules/user/user.css
+++ b/submodules/user/user.css
@@ -147,6 +147,16 @@
 	display: block;
 }
 
+.callflows-port #user-form .caller-id-emergency-target {
+	margin-bottom: 10px;
+}
+
+.callflows-port #user-form {
+	.chosen-container, .chosen-drop, #priv_level {
+		width: 224px !important;
+	}
+}
+
 /* Hotdesk devices */
 .callflows-port #user-form #hotdesk_devices {
 	/*width: 400px;*/

--- a/submodules/user/user.js
+++ b/submodules/user/user.js
@@ -648,7 +648,10 @@ define(function(require) {
 					'caller_id.external.number': { regex: /^[+]?[0-9\s\-.()]*$/ },
 					'caller_id.emergency.number': { regex: /^[+]?[0-9\s\-.()]*$/ },
 					'caller_id.asserted.number': { phoneNumber: true },
-					'caller_id.asserted.realm': { realm: true }
+					'caller_id.asserted.realm': { realm: true },
+					'e911.street_address_extended': {
+						maxlength: 32
+					}
 				},
 				messages: {
 					username: { regex: self.i18n.active().callflows.user.validation.username },

--- a/submodules/user/views/edit.html
+++ b/submodules/user/views/edit.html
@@ -213,6 +213,13 @@
 					</div>
 				{{/if}}
 				</div>
+
+				<div class="clearfix">
+					<label for="e911_street_address_extended">{{ i18n.callflows.user.e911.extended_address }}</label>
+					<div class="input">
+						<input class="span4" id="e911_street_address_extended" name="e911.street_address_extended" type="text" placeholder="{{ i18n.callflows.user.e911.extended_address_placeholder }}" value="{{data.e911.street_address_extended}}" rel="popover" data-content="{{ i18n.callflows.user.e911.extended_address_data_content }}" />
+					</div>
+				</div>
 				<hr />
 
 			{{#if showPAssertedIdentity}}


### PR DESCRIPTION


* MACF-95: Add new 'Extended Address' field for Users

* Add 'Extended Address' to sip devices

* Add 'Extended Address' to ata devices

* Add 'Extended Address' to fax devices

* Add 'Extended Address' to mobile devices

* Add 'Extended Address' to softphone devices

* Fix error