### PR TITLE
MACF-108: Show/Hide 'extended address' based on the configuration in monster.config.featureFlags.enable911ExtAddress

### DIFF
--- a/submodules/device/device.js
+++ b/submodules/device/device.js
@@ -536,7 +536,8 @@ define(function(require) {
 					name: 'device-' + data.data.device_type,
 					data: _.merge({
 						hasExternalCallerId: hasExternalCallerId,
-						showPAssertedIdentity: monster.config.whitelabel.showPAssertedIdentity
+						showPAssertedIdentity: monster.config.whitelabel.showPAssertedIdentity,
+						enable911ExtAddress: _.get(monster, 'config.featureFlags.enable911ExtAddress', false)
 					}, _.pick(data.extra, [
 						'phoneNumbers'
 					]), data),

--- a/submodules/device/views/device-ata.html
+++ b/submodules/device/views/device-ata.html
@@ -138,12 +138,14 @@
 					{{/if}}
 					</div>
 
+					{{#if enable911ExtAddress}}
 					<div class="clearfix">
 						<label for="additional_information">{{ i18n.callflows.device.additional_information.title }}</label>
 						<div class="input">
 							<input class="span4" id="additional_information" name="additional_information" type="text" placeholder="{{ i18n.callflows.user.additional_information.placeholder }}" value="{{ data.additional_information }}" rel="popover" data-content="{{ i18n.callflows.device.additional_information.data_content }}" />
 						</div>
 					</div>
+					{{/if}}
 					<hr />
 
 				{{#if showPAssertedIdentity}}

--- a/submodules/device/views/device-fax.html
+++ b/submodules/device/views/device-fax.html
@@ -153,12 +153,14 @@
 					{{/if}}
 					</div>
 
+					{{#if enable911ExtAddress}}
 					<div class="clearfix">
 						<label for="additional_information">{{ i18n.callflows.device.additional_information.title }}</label>
 						<div class="input">
 							<input class="span4" id="additional_information" name="additional_information" type="text" placeholder="{{ i18n.callflows.device.additional_information.placeholder }}" value="{{ data.additional_information }}" rel="popover" data-content="{{ i18n.callflows.device.additional_information.data_content }}" />
 						</div>
 					</div>
+					{{/if}}
 					<hr />
 
 				{{#if showPAssertedIdentity}}

--- a/submodules/device/views/device-mobile.html
+++ b/submodules/device/views/device-mobile.html
@@ -140,12 +140,14 @@
 					{{/if}}
 					</div>
 
+					{{#if enable911ExtAddress}}
 					<div class="clearfix">
 						<label for="additional_information">{{ i18n.callflows.device.additional_information.title }}</label>
 						<div class="input">
 							<input class="span4" id="additional_information" name="additional_information" type="text" placeholder="{{ i18n.callflows.device.additional_information.placeholder }}" value="{{ data.additional_information }}" rel="popover" data-content="{{ i18n.callflows.device.additional_information.data_content }}" />
 						</div>
 					</div>
+					{{/if}}
 					<hr />
 
 				{{#if showPAssertedIdentity}}

--- a/submodules/device/views/device-sip_device.html
+++ b/submodules/device/views/device-sip_device.html
@@ -182,12 +182,14 @@
 					{{/if}}
 					</div>
 
+					{{#if enable911ExtAddress}}
 					<div class="clearfix">
 						<label for="additional_information">{{ i18n.callflows.device.additional_information.title }}</label>
 						<div class="input">
 							<input class="span4" id="additional_information" name="additional_information" type="text" placeholder="{{ i18n.callflows.device.additional_information.placeholder }}" value="{{ data.additional_information }}" rel="popover" data-content="{{ i18n.callflows.device.additional_information.data_content }}" />
 						</div>
 					</div>
+					{{/if}}
 					<hr />
 
 				{{#if showPAssertedIdentity}}

--- a/submodules/device/views/device-softphone.html
+++ b/submodules/device/views/device-softphone.html
@@ -155,12 +155,14 @@
 					{{/if}}
 					</div>
 
+					{{#if enable911ExtAddress}}
 					<div class="clearfix">
 						<label for="additional_information">{{ i18n.callflows.device.additional_information.title }}</label>
 						<div class="input">
 							<input class="span4" id="additional_information" name="additional_information" type="text" placeholder="{{ i18n.callflows.device.additional_information.placeholder }}" value="{{ data.additional_information }}" rel="popover" data-content="{{ i18n.callflows.device.additional_information.data_content }}" />
 						</div>
 					</div>
+					{{/if}}
 					<hr />
 
 				{{#if showPAssertedIdentity}}

--- a/submodules/user/user.js
+++ b/submodules/user/user.js
@@ -525,6 +525,7 @@ define(function(require) {
 					data: _.merge({
 						hasExternalCallerId: hasExternalCallerId,
 						showPAssertedIdentity: monster.config.whitelabel.showPAssertedIdentity,
+						enable911ExtAddress: _.get(monster, 'config.featureFlags.enable911ExtAddress', false),
 						data: {
 							vm_to_email_enabled: _.get(data, 'data.vm_to_email_enabled', true),
 							additional_information: _.get(data, 'additional_information')

--- a/submodules/user/views/edit.html
+++ b/submodules/user/views/edit.html
@@ -214,12 +214,14 @@
 				{{/if}}
 				</div>
 
+				{{#if enable911ExtAddress}}
 				<div class="clearfix">
 					<label for="additional_information">{{ i18n.callflows.user.additional_information.title }}</label>
 					<div class="input">
 						<input class="span4" id="additional_information" name="additional_information" type="text" placeholder="{{ i18n.callflows.user.additional_information.placeholder }}" value="{{ data.additional_information }}" rel="popover" data-content="{{ i18n.callflows.user.additional_information.data_content }}" />
 					</div>
 				</div>
+				{{/if}}
 				<hr />
 
 			{{#if showPAssertedIdentity}}


### PR DESCRIPTION
The configuration will be set in the config.js file like this:
<img width="608" height="274" alt="image-20260721-201532" src="https://github.com/user-attachments/assets/f51e1371-8127-4a1e-a91d-0263b9ebd5c3" />

1. If the setting is not set, then the Extended Address will be hidden
2. If the setting is set to false, then the Extended Address will be hidden
3. If the setting is set to true, then the Extended Address will be shown