### PR TITLE
MACF-113: Fix fields the entity dirty check does not see

### DIFF
--- a/app.js
+++ b/app.js
@@ -559,7 +559,9 @@ define(function(require) {
 				flow: self.flow.root && self.flow.root.children[0]
 					? self.flow.root.children[0].serialize()
 					: {},
-				contact_list: self.flow.contact_list || {}
+				contact_list: self.flow.contact_list || {},
+				caption_map: self.flow.caption_map || {},
+				ui_is_main_number_cf: (self.dataCallflow && self.dataCallflow.ui_is_main_number_cf) || false
 			});
 		},
 

--- a/submodules/blacklist/blacklist.js
+++ b/submodules/blacklist/blacklist.js
@@ -181,6 +181,8 @@ define(function(require) {
 							})));
 
 						$('#number_value', template).val('');
+
+						callbacks.markEntityDirty && callbacks.markEntityDirty();
 					}
 				};
 
@@ -207,6 +209,8 @@ define(function(require) {
 
 			$(template).delegate('.delete-number', 'click', function(e) {
 				$(this).parents('.number-wrapper').remove();
+
+				callbacks.markEntityDirty && callbacks.markEntityDirty();
 			});
 
 			$('#cancel_number', template).click(function(e) {
@@ -217,6 +221,10 @@ define(function(require) {
 			});
 
 			$('.blacklist-save', template).click(function() {
+				if ($(this).hasClass('disabled')) {
+					return;
+				}
+
 				var formData = monster.ui.getFormData('blacklist-form'),
 					cleanData = self.blacklistCleanFormData(formData),
 					mapNumbers = {};

--- a/submodules/conference/conference.js
+++ b/submodules/conference/conference.js
@@ -313,7 +313,7 @@ define(function(require) {
 						/* Create */
 						if (!_id) {
 							$('#owner_id', conference_html).append('<option id="' + _data.id + '" value="' + _data.id + '">' + _data.first_name + ' ' + _data.last_name + '</option>');
-							$('#owner_id', conference_html).val(_data.id);
+							$('#owner_id', conference_html).val(_data.id).trigger('change');
 							$('#edit_link', conference_html).show();
 						} else {
 							/* Update */
@@ -322,6 +322,7 @@ define(function(require) {
 							/* Delete */
 							} else {
 								$('#owner_id #' + _id, conference_html).remove();
+								$('#owner_id', conference_html).trigger('change');
 								$('#edit_link', conference_html).hide();
 							}
 						}

--- a/submodules/device/device.js
+++ b/submodules/device/device.js
@@ -75,7 +75,8 @@ define(function(require) {
 					delete_success: _callbacks.delete_success,
 					delete_error: _callbacks.delete_error,
 					after_render: _callbacks.after_render,
-					markEntityDirty: _callbacks.markEntityDirty
+					markEntityDirty: _callbacks.markEntityDirty,
+					rebindTracking: _callbacks.rebindTracking
 				},
 				defaults = {
 					data: $.extend(true, {
@@ -836,6 +837,8 @@ define(function(require) {
 						self.deviceFormatData(data);
 
 						self.deviceRender(data, $('.media_pane', device_html), callbacks);
+
+						callbacks.rebindTracking && callbacks.rebindTracking();
 					}
 				});
 			}

--- a/submodules/device/device.js
+++ b/submodules/device/device.js
@@ -690,7 +690,7 @@ define(function(require) {
 							/* Create */
 							if (!_id) {
 								$('#owner_id', device_html).append('<option id="' + user.id + '" value="' + user.id + '">' + user.first_name + ' ' + user.last_name + '</option>');
-								$('#owner_id', device_html).val(user.id);
+								$('#owner_id', device_html).val(user.id).trigger('change');
 								$('#edit_link', device_html).show();
 							} else {
 								/* Update */
@@ -699,6 +699,7 @@ define(function(require) {
 								/* Delete */
 								} else {
 									$('#owner_id #' + _id, device_html).remove();
+									$('#owner_id', device_html).trigger('change');
 									$('#edit_link', device_html).hide();
 								}
 							}
@@ -804,7 +805,7 @@ define(function(require) {
 							/* Create */
 							if (!_id) {
 								$('#music_on_hold_media_id', device_html).append('<option id="' + media.id + '" value="' + media.id + '">' + media.name + '</option>');
-								$('#music_on_hold_media_id', device_html).val(media.id);
+								$('#music_on_hold_media_id', device_html).val(media.id).trigger('change');
 
 								$('#edit_link_media', device_html).show();
 							} else {
@@ -814,6 +815,7 @@ define(function(require) {
 								/* Delete */
 								} else {
 									$('#music_on_hold_media_id #' + _id, device_html).remove();
+									$('#music_on_hold_media_id', device_html).trigger('change');
 									$('#edit_link_media', device_html).hide();
 								}
 							}

--- a/submodules/directory/directory.js
+++ b/submodules/directory/directory.js
@@ -115,6 +115,8 @@ define(function(require) {
 
 					$user.val('empty_option_user');
 					$callflow.val('empty_option_callflow');
+
+					callbacks.debouncedCheck && callbacks.debouncedCheck();
 				} else {
 					monster.ui.alert('warning', self.i18n.active().callflows.directory.noDataSelected);
 				}

--- a/submodules/faxbox/faxbox.js
+++ b/submodules/faxbox/faxbox.js
@@ -171,6 +171,7 @@ define(function(require) {
 					},
 					delete_error: _callbacks.delete_error,
 					after_render: _callbacks.after_render,
+					debouncedCheck: _callbacks.debouncedCheck,
 					rebindTracking: _callbacks.rebindTracking
 				};
 
@@ -367,7 +368,12 @@ define(function(require) {
 						/* Create */
 						if (!_id) {
 							$('#owner_id', faxbox_html).append('<option id="' + _data.id + '" value="' + _data.id + '">' + _data.first_name + ' ' + _data.last_name + '</option>');
+							// no trigger('change') here: this select's own change handler
+							// re-renders the whole form from the user list fetched at load,
+							// which does not contain the user just created
 							$('#owner_id', faxbox_html).val(_data.id);
+
+							callbacks.debouncedCheck && callbacks.debouncedCheck();
 						} else {
 							/* Update */
 							if ('id' in _data) {
@@ -375,6 +381,8 @@ define(function(require) {
 							/* Delete */
 							} else {
 								$('#owner_id #' + _id, faxbox_html).remove();
+
+								callbacks.debouncedCheck && callbacks.debouncedCheck();
 							}
 						}
 					}

--- a/submodules/menu/menu.js
+++ b/submodules/menu/menu.js
@@ -190,7 +190,7 @@ define(function(require) {
 
 						if (!_id) {
 							$('#media_greeting', menu_html).append('<option id="' + dataMedia.id + '" value="' + dataMedia.id + '">' + dataMedia.name + '</option>');
-							$('#media_greeting', menu_html).val(dataMedia.id);
+							$('#media_greeting', menu_html).val(dataMedia.id).trigger('change');
 
 							$('#edit_link_media', menu_html).show();
 						} else {
@@ -200,6 +200,7 @@ define(function(require) {
 							/* Delete */
 							} else {
 								$('#media_greeting #' + _id, menu_html).remove();
+								$('#media_greeting', menu_html).trigger('change');
 								$('#edit_link_media', menu_html).hide();
 							}
 						}

--- a/submodules/user/user.js
+++ b/submodules/user/user.js
@@ -880,7 +880,7 @@ define(function(require) {
 						/* Create */
 						if (!_id) {
 							$('#music_on_hold_media_id', user_html).append('<option id="' + media.id + '" value="' + media.id + '">' + media.name + '</option>');
-							$('#music_on_hold_media_id', user_html).val(media.id);
+							$('#music_on_hold_media_id', user_html).val(media.id).trigger('change');
 
 							$('#edit_link_media', user_html).show();
 						} else {
@@ -890,6 +890,7 @@ define(function(require) {
 							/* Delete */
 							} else {
 								$('#music_on_hold_media_id #' + _id, user_html).remove();
+								$('#music_on_hold_media_id', user_html).trigger('change');
 								$('#edit_link_media', user_html).hide();
 							}
 						}

--- a/submodules/vmbox/vmbox.js
+++ b/submodules/vmbox/vmbox.js
@@ -398,7 +398,7 @@ define(function(require) {
 						/* Create */
 						if (!_id) {
 							$('#owner_id', vmbox_html).append('<option id="' + _data.id + '" value="' + _data.id + '">' + _data.first_name + ' ' + _data.last_name + '</option>');
-							$('#owner_id', vmbox_html).val(_data.id);
+							$('#owner_id', vmbox_html).val(_data.id).trigger('change');
 
 							$('#edit_link', vmbox_html).show();
 							$('#timezone', vmbox_html).val(_data.timezone);
@@ -410,6 +410,7 @@ define(function(require) {
 							} else {
 								/* Delete */
 								$('#owner_id #' + _id, vmbox_html).remove();
+								$('#owner_id', vmbox_html).trigger('change');
 								$('#edit_link', vmbox_html).hide();
 								$('#timezone', vmbox_html).val('America/Los_Angeles');
 							}
@@ -438,7 +439,7 @@ define(function(require) {
 						/* Create */
 						if (!_id) {
 							$('#media_unavailable', vmbox_html).append('<option id="' + _data.id + '" value="' + _data.id + '">' + _data.name + '</option>');
-							$('#media_unavailable', vmbox_html).val(_data.id);
+							$('#media_unavailable', vmbox_html).val(_data.id).trigger('change');
 
 							$('#edit_link_media', vmbox_html).show();
 						} else {
@@ -448,6 +449,7 @@ define(function(require) {
 							} else {
 								/* Delete */
 								$('#media_unavailable #' + _id, vmbox_html).remove();
+								$('#media_unavailable', vmbox_html).trigger('change');
 								$('#edit_link_media', vmbox_html).hide();
 							}
 						}
@@ -475,7 +477,7 @@ define(function(require) {
 						/* Create */
 						if (!_id) {
 							$('#media_temporary_unavailable', vmbox_html).append('<option id="' + _data.id + '" value="' + _data.id + '">' + _data.name + '</option>');
-							$('#media_temporary_unavailable', vmbox_html).val(_data.id);
+							$('#media_temporary_unavailable', vmbox_html).val(_data.id).trigger('change');
 
 							$('#edit_link_temporary_media', vmbox_html).show();
 						} else {
@@ -485,6 +487,7 @@ define(function(require) {
 							} else {
 								/* Delete */
 								$('#media_temporary_unavailable #' + _id, vmbox_html).remove();
+								$('#media_temporary_unavailable', vmbox_html).trigger('change');
 								$('#edit_link_temporary_media', vmbox_html).hide();
 							}
 						}


### PR DESCRIPTION
Five gaps in the entity dirty tracking added by MSPB-394 and extended by
MACF-109, found while re-testing MACF-109. The tracking snapshots the named
form fields on load and re-compares on every change, enabling save only when
the two differ. Each gap is a real change that snapshot cannot see, so save
stays disabled and the edit cannot be saved at all.

- blocklist: add and delete never enabled save. Add also cleared the one named
  input, which reset the snapshot and re-disabled the button 150ms later.
- inline create, update and delete beside the owner and media selects set the
  option from code, firing no change event. 9 create and 9 delete sites across
  conference, device, faxbox, menu, user and vmbox.
- the device type switch re-renders through a path that skips the hook the
  tracker binds on. Rebound after the re-render, as faxbox already does.
- adding a directory row ran no check while delete already did.
- the main number flag and caption map were missing from the callflow compare.

The blocklist and faxbox save handlers also get the disabled guard they were
missing; without it the greyed button still submitted.

Faxbox is deliberately different: firing the change event there rebuilds the
form, discarding everything typed into a new fax box and dropping the owner
just created, so that site runs the check directly instead.

Three more fixes came out of review. The faxbox form registered its user popup
callback under the wrong key, so the popup never called it and the dirty check
added on that path never ran. The device owner popup decided update versus
delete on what went in rather than what came back, so the delete branch could
never run and a deleted user stayed selected. Creating a user on an account
with no tier enrollments dropped the saved user on the way out, so the popup
stayed open, the user was never assigned, and the Users list did not refresh;
present since MACF-106.

Blocklist add and delete now persist through the API, and the greyed button
refuses to submit. The type switch keeps tracking bound, and a codec moved in
the rebuilt form still reaches the tracker. The main number flag is detected
on its own. Every entity type that has data goes disabled, then enabled on a
change, then disabled again when it is reverted, nine of nine. The lint delta
against master is empty and the build is green on both branches.

One exception to that revert behaviour: changes that go through the
force-dirty path, such as moving a codec back or removing a blocklist number
you just added, leave the button enabled. That path sets a flag the comparison
cannot clear, which is existing behaviour from MACF-109 and is left as is
here. A follow-up ticket covers reworking it so the state is compared rather
than flagged.

[MACF-113](https://oomacorp.atlassian.net/browse/MACF-113)
